### PR TITLE
Added reorder buttons to the champion group toolbar

### DIFF
--- a/src/plugins/champion-groups/config-panel/index.ts
+++ b/src/plugins/champion-groups/config-panel/index.ts
@@ -188,6 +188,19 @@ export default function(ace: Ace, settings: SettingsAPI) {
                 this.currentGroup = this.groups[0] || null;
             }, () => { /* Do nothing. */ });
         }
+
+        /**
+         * Moves the currently selected group, if one is selected.
+         * No effect if already at the edge.
+         * +1 = down, -1 = up.
+         */
+        moveGroup(dir: number) {
+            if (!this.currentGroup) return;
+            var loc = this.groups.indexOf(this.currentGroup!);
+            if (loc+dir >= this.groups.length || loc+dir < 0) return;
+            this.groups.splice(loc, 1, this.groups[loc+dir]);
+            this.groups.splice(loc+dir, 1, this.currentGroup);
+        }
     };
 
     return ChampionGroupsConfigPanel;

--- a/src/plugins/champion-groups/config-panel/layout.html
+++ b/src/plugins/champion-groups/config-panel/layout.html
@@ -15,6 +15,8 @@
             <div class="toolbar">
                 <div class="plus" @click="promptGroupAdd()"></div>
                 <div class="edit" @click="editGroup()"></div>
+                <div class="up" @click="moveGroup(-1)"></div>
+                <div class="down" @click="moveGroup(1)"></div>
                 <div class="remove" @click="removeGroup()"></div>
             </div>
         </div>

--- a/src/plugins/champion-groups/config-panel/style.styl
+++ b/src/plugins/champion-groups/config-panel/style.styl
@@ -33,7 +33,7 @@
             flex 0 30px
             display flex
 
-            .plus, .remove, .edit
+            .plus, .remove, .edit, .up, .down
                 cursor pointer
                 width 30px
                 height 30px
@@ -43,7 +43,7 @@
                 background-color #f0e6d2
                 transition background-color 0.3s ease
 
-            .plus:hover, .remove:hover, .edit:hover
+            .plus:hover, .remove:hover, .edit:hover, .up:hover, .down:hover
                 background-color #c8aa6e
             
             .plus
@@ -54,6 +54,12 @@
 
             .remove
                 -webkit-mask-image url('~open-iconic/svg/trash.svg')
+
+            .up
+                -webkit-mask-image url('~open-iconic/svg/chevron-top.svg')
+
+            .down
+                -webkit-mask-image url('~open-iconic/svg/chevron-bottom.svg')
 
     .contents
         flex 1

--- a/src/plugins/champion-groups/index.ts
+++ b/src/plugins/champion-groups/index.ts
@@ -17,7 +17,7 @@ export interface Group {
 
 export default (<PluginDescription>{
     name: "champion-groups",
-    version: "1.2.0",
+    version: "1.3.0",
     description: "Adds custom champion group filters for champion select.",
     dependencies: {
         "settings": "^1.0.0"


### PR DESCRIPTION
I thought of making it drag-and-drop like the new masteries/runes, but wasn't sure how to go about it.